### PR TITLE
Fallback to `default-orginzation`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import { workspace } from 'vscode';
 const SONAR_DOTNET_SECTION = 'sonar-dotnet-vscode';
 
 export function getOrganizationKey(): string | undefined {
-    return workspace.getConfiguration(SONAR_DOTNET_SECTION).get<string>('connection.sonar.organizationKey');
+    return workspace.getConfiguration(SONAR_DOTNET_SECTION).get<string>('connection.sonar.organizationKey','default-organization');
 }
 
 export function getToken(): string | undefined {


### PR DESCRIPTION
Implemented based on suggestion from sonarqube engineers: https://community.sonarsource.com/t/issue-with-inherited-sonar-organization-property-using-a-self-hosted-instance/16004/2